### PR TITLE
Fix typo in delete cols fn

### DIFF
--- a/gen_debiased_nli/utils.py
+++ b/gen_debiased_nli/utils.py
@@ -63,7 +63,7 @@ def split_dataset(dataset: Dataset, percentage, seed=None):
 
 
 def del_columns(dataset):
-    dataset.remove_columns_(
+    dataset.remove_columns(
         list(filter(lambda n: n not in ["premise", "hypothesis", "label"], dataset.column_names))
     )
     return dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torch >= 1.7
 nltk
 sklearn
 json_lines
+transformers


### PR DESCRIPTION
`Dataset` doesn't have a `remove_columns_` method - rename to `remove_columns`

Should fix #4 and allow use of built in HF datasets for eval, eg `--dev_data mnli`